### PR TITLE
Added seconds since 1981-01-01 to the list of valid times in nctimeToPosix

### DIFF
--- a/R/ncUtils.R
+++ b/R/ncUtils.R
@@ -13,6 +13,9 @@ ncTimeToPosix <- function(vals, units) {
     if(units == 'seconds since 1970-01-01T00:00:00Z') {
         return( as.POSIXct(vals, origin = '1970-01-01 00:00:00', tz='UTC'))
     }
+    if(units == 'seconds since 1981-01-01 00:00:00') {
+        return( as.POSIXct(vals, origin = '1981-01-01 00:00:00', tz='UTC'))
+    }
     if(units == 'count') {
         return(vals)
     }


### PR DESCRIPTION
While working with this library, I encountered netCDF files that use seconds since 1981-01-01 as their unit for time. I figured since I ran into it, others might as well, and it's a trivial enough thing to add so I made a PR for it. 