### PR TITLE
Added a null check for the part of the file that updates the names of…

### DIFF
--- a/R/ncToData.R
+++ b/R/ncToData.R
@@ -90,7 +90,9 @@ ncToData <- function(data, nc, buffer = c(0,0,0), FUN = c(mean),
         pb <- txtProgressBar(min=0, max=nrow(data), style=3)
     }
     for(v in varNames) {
+      if(!is_null(nc$var[[v]]$dim)) {
         names(nc$var[[v]]$dim) <- names(nc$dim)[nc$var[[v]]$dimids + 1]
+      }
     }
     for(i in 1:nrow(data)) {
         varData <- getVarData(data[i,], nc=nc, var=varNames, buffer = buffer,


### PR DESCRIPTION
… variables in the NC file. While running this on my code, I found that some variables that weren't cut from the NC object with dropVar had null values for the $dim field. Since this makes R break, and I'm not sure in advance which columns in which NC files across the set I hope to use will fall into this category, I decided instead to add a check that skips the step if $dims is null. 

I hope that this is a correct way to handle this, if not, please let me know. I am still new to PAMmisc and may be missing some context.  